### PR TITLE
Add table size pragma

### DIFF
--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -182,7 +182,11 @@ string PragmaCopyDatabase(ClientContext &context, const FunctionParameters &para
 }
 
 string PragmaDatabaseSize(ClientContext &context, const FunctionParameters &parameters) {
-	return "SELECT * FROM pragma_database_size();";
+        return "SELECT * FROM pragma_database_size();";
+}
+
+string PragmaTableSize(ClientContext &context, const FunctionParameters &parameters) {
+        return StringUtil::Format("SELECT * FROM pragma_table_size('%s');", parameters.values[0].ToString());
 }
 
 string PragmaStorageInfo(ClientContext &context, const FunctionParameters &parameters) {
@@ -199,8 +203,9 @@ string PragmaUserAgent(ClientContext &context, const FunctionParameters &paramet
 
 void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaCall("table_info", PragmaTableInfo, {LogicalType::VARCHAR}));
-	set.AddFunction(PragmaFunction::PragmaCall("storage_info", PragmaStorageInfo, {LogicalType::VARCHAR}));
-	set.AddFunction(PragmaFunction::PragmaCall("metadata_info", PragmaMetadataInfo, {}));
+        set.AddFunction(PragmaFunction::PragmaCall("storage_info", PragmaStorageInfo, {LogicalType::VARCHAR}));
+        set.AddFunction(PragmaFunction::PragmaCall("table_size", PragmaTableSize, {LogicalType::VARCHAR}));
+        set.AddFunction(PragmaFunction::PragmaCall("metadata_info", PragmaMetadataInfo, {}));
 	set.AddFunction(PragmaFunction::PragmaStatement("show_tables", PragmaShowTables));
 	set.AddFunction(PragmaFunction::PragmaStatement("show_tables_expanded", PragmaShowTablesExpanded));
 	set.AddFunction(PragmaFunction::PragmaStatement("show_databases", PragmaShowDatabases));

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library_unity(
   duckdb_views.cpp
   pragma_collations.cpp
   pragma_database_size.cpp
+  pragma_table_size.cpp
   pragma_metadata_info.cpp
   pragma_storage_info.cpp
   pragma_table_info.cpp

--- a/src/function/table/system/pragma_table_size.cpp
+++ b/src/function/table/system/pragma_table_size.cpp
@@ -1,0 +1,86 @@
+#include "duckdb/function/table/system_functions.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+
+namespace duckdb {
+
+struct PragmaTableSizeBindData : public TableFunctionData {
+    explicit PragmaTableSizeBindData(TableCatalogEntry &table_p) : table(table_p) {
+    }
+
+    TableCatalogEntry &table;
+};
+
+struct PragmaTableSizeState : public GlobalTableFunctionState {
+    PragmaTableSizeState() : returned(false) {
+    }
+    bool returned;
+};
+
+static unique_ptr<FunctionData> PragmaTableSizeBind(ClientContext &context, TableFunctionBindInput &input,
+                                                   vector<LogicalType> &return_types, vector<string> &names) {
+    names.emplace_back("table_name");
+    return_types.emplace_back(LogicalType::VARCHAR);
+
+    names.emplace_back("table_size");
+    return_types.emplace_back(LogicalType::VARCHAR);
+
+    names.emplace_back("block_size");
+    return_types.emplace_back(LogicalType::BIGINT);
+
+    names.emplace_back("total_blocks");
+    return_types.emplace_back(LogicalType::BIGINT);
+
+    auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
+    Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+    auto &table = Catalog::GetEntry<TableCatalogEntry>(context, qname.catalog, qname.schema, qname.name);
+    return make_uniq<PragmaTableSizeBindData>(table);
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaTableSizeInit(ClientContext &context, TableFunctionInitInput &input) {
+    return make_uniq<PragmaTableSizeState>();
+}
+
+void PragmaTableSizeFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+    auto &bind_data = data_p.bind_data->Cast<PragmaTableSizeBindData>();
+    auto &state = data_p.global_state->Cast<PragmaTableSizeState>();
+    if (state.returned) {
+        return;
+    }
+
+    unordered_set<block_id_t> blocks;
+    auto segments = bind_data.table.GetColumnSegmentInfo();
+    for (auto &info : segments) {
+        if (!info.persistent) {
+            continue;
+        }
+        blocks.insert(info.block_id);
+        for (auto &bid : info.additional_blocks) {
+            blocks.insert(bid);
+        }
+    }
+    auto &block_manager = bind_data.table.GetStorage().GetTableIOManager().GetBlockManagerForRowData();
+    idx_t block_size = block_manager.GetBlockSize();
+    idx_t total_blocks = blocks.size();
+    idx_t bytes = total_blocks * block_size;
+
+    idx_t col = 0;
+    output.data[col++].SetValue(0, Value(bind_data.table.name));
+    output.data[col++].SetValue(0, Value(StringUtil::BytesToHumanReadableString(bytes)));
+    output.data[col++].SetValue(0, Value::BIGINT(NumericCast<int64_t>(block_size)));
+    output.data[col++].SetValue(0, Value::BIGINT(NumericCast<int64_t>(total_blocks)));
+    output.SetCardinality(1);
+    state.returned = true;
+}
+
+void PragmaTableSize::RegisterFunction(BuiltinFunctions &set) {
+    set.AddFunction(TableFunction("pragma_table_size", {LogicalType::VARCHAR}, PragmaTableSizeFunction,
+                                  PragmaTableSizeBind, PragmaTableSizeInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -14,9 +14,10 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	PragmaCollations::RegisterFunction(*this);
 	PragmaTableInfo::RegisterFunction(*this);
 	PragmaStorageInfo::RegisterFunction(*this);
-	PragmaMetadataInfo::RegisterFunction(*this);
-	PragmaDatabaseSize::RegisterFunction(*this);
-	PragmaUserAgent::RegisterFunction(*this);
+        PragmaMetadataInfo::RegisterFunction(*this);
+        PragmaDatabaseSize::RegisterFunction(*this);
+        PragmaTableSize::RegisterFunction(*this);
+        PragmaUserAgent::RegisterFunction(*this);
 
 	DuckDBColumnsFun::RegisterFunction(*this);
 	DuckDBConstraintsFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -40,7 +40,11 @@ struct PragmaPlatform {
 };
 
 struct PragmaDatabaseSize {
-	static void RegisterFunction(BuiltinFunctions &set);
+        static void RegisterFunction(BuiltinFunctions &set);
+};
+
+struct PragmaTableSize {
+        static void RegisterFunction(BuiltinFunctions &set);
 };
 
 struct DuckDBSchemasFun {

--- a/test/sql/pragma/pragma_table_size.test
+++ b/test/sql/pragma/pragma_table_size.test
@@ -1,0 +1,17 @@
+# name: test/sql/pragma/pragma_table_size.test
+# description: Test PRAGMA table_size
+# group: [pragma]
+
+statement ok
+CREATE TABLE tbl(i INTEGER);
+
+statement ok
+INSERT INTO tbl SELECT i FROM range(1000);
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT total_blocks > 0 FROM pragma_table_size('tbl');
+----
+true


### PR DESCRIPTION
## Summary
- implement `pragma_table_size` to report disk blocks used by a table
- register pragma in built-ins and SQL pragma queries
- add regression test

## Testing
- `make format-changes` *(fails: clang-format missing)*
- `make unittest` *(fails to compile in environment)*

------
https://chatgpt.com/codex/tasks/task_e_685c94e0e8f4832ebb96d5a55994d495